### PR TITLE
Fix: Right-justify mobile menu icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,10 +283,10 @@
 
             <!-- Mobile Menu Button -->
             <div class="md:hidden">
-                <button id="hamburger-button" class="text-white focus:outline-none p-1 rounded hover:bg-gray-700 mr-4">
+                <button id="hamburger-button" class="text-white focus:outline-none p-1 rounded hover:bg-gray-700">
                     <svg class="h-6 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor"><path d="M4 6h16M4 12h16m-7 6h7"></path></svg>
                 </button>
-                <button id="close-button" class="hidden text-white focus:outline-none p-1 rounded hover:bg-gray-700 mr-4">
+                <button id="close-button" class="hidden text-white focus:outline-none p-1 rounded hover:bg-gray-700">
                     <svg class="h-6 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor"><path d="M6 18L18 6M6 6l12 12"></path></svg>
                 </button>
             </div>


### PR DESCRIPTION
Removes the right margin (`mr-4`) from the hamburger and close buttons in the header.

This change ensures that your mobile menu icons (hamburger and close) are aligned to the far right of the header area on smaller screens. The parent container `div.container` uses `justify-between`, which pushes the icon's wrapper `div.md:hidden` to the right. By removing the explicit right margin on the buttons themselves, they now sit flush against the right edge of their container, and thus, the header.