### PR TITLE
Fix: Prevent carousel scroll from interfering with modal navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,6 +483,11 @@
 
             // Function to update the current image index and arrow button states
             function updateCarouselSelectionAndArrows() {
+                // If modal is active, don't let carousel scroll events change the shared index
+                if (imageModal.classList.contains('active')) {
+                    return;
+                }
+
                 // Determine the visible center point of the carousel container
                 const carouselCenter = galleryCarouselContainer.scrollLeft + galleryCarouselContainer.offsetWidth / 2;
                 let closestImageIndex = 0;


### PR DESCRIPTION
The gallery lightbox was skipping images on the first click of the next/previous arrows. This was due to the `currentOverallImageIndex` being updated by the carousel's scroll handler (`updateCarouselSelectionAndArrows`) even when the modal was active.

The fix modifies `updateCarouselSelectionAndArrows` to return early if the image modal is active (`imageModal.classList.contains('active')`). This ensures that the modal's navigation logic uses the index established when it was opened or by its own navigation controls, without interference from background carousel scroll events.